### PR TITLE
SafeImage - Allows us to use nil UIImages, helps for dev purposes when builds are having issues

### DIFF
--- a/OpenArtemis.xcodeproj/project.pbxproj
+++ b/OpenArtemis.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1BD488602CD82DD200B59F09 /* SafeImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD4885F2CD82DD200B59F09 /* SafeImage.swift */; };
 		652E2AA72B25B19C0075911F /* PrivacyTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652E2AA62B25B19C0075911F /* PrivacyTab.swift */; };
 		652E2AA92B25B1F10075911F /* HeroBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652E2AA82B25B1F10075911F /* HeroBox.swift */; };
 		653245C12B2AF5D500227019 /* OOBE_PrivacySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653245BC2B2AF5D500227019 /* OOBE_PrivacySelector.swift */; };
@@ -119,6 +120,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1BD4885F2CD82DD200B59F09 /* SafeImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeImage.swift; sourceTree = "<group>"; };
 		652E2AA62B25B19C0075911F /* PrivacyTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyTab.swift; sourceTree = "<group>"; };
 		652E2AA82B25B1F10075911F /* HeroBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroBox.swift; sourceTree = "<group>"; };
 		653245BC2B2AF5D500227019 /* OOBE_PrivacySelector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OOBE_PrivacySelector.swift; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 		6535AC012B4563A100E6A2DD /* Images */ = {
 			isa = PBXGroup;
 			children = (
+				1BD4885F2CD82DD200B59F09 /* SafeImage.swift */,
 				6535AC022B4563AC00E6A2DD /* LiveTextInteraction.swift */,
 			);
 			path = Images;
@@ -795,6 +798,7 @@
 				BB38FC5E2B991DCE002994F1 /* DefaultFavoritesView.swift in Sources */,
 				65D3DBB62B1B1F2200BCCD38 /* LoadingView.swift in Sources */,
 				BBE434772B1BE35F00886CAB /* PersistenceController.swift in Sources */,
+				1BD488602CD82DD200B59F09 /* SafeImage.swift in Sources */,
 				BB3387032B2C171C00EF4D5C /* Theme Wrappers.swift in Sources */,
 				BB391FC82B1ADE790014FB18 /* NavPayloads.swift in Sources */,
 				BBEB46E32B34999B00C33D33 /* ScrapeSearch.swift in Sources */,

--- a/OpenArtemis/Views/Images/SafeImage.swift
+++ b/OpenArtemis/Views/Images/SafeImage.swift
@@ -1,0 +1,39 @@
+//
+//  SafeImage.swift
+//  OpenArtemis
+//
+//  Created by Mike DiGovanni on 11/3/24.
+//
+import Foundation
+import SwiftUI
+
+struct SafeImage: View {
+    var uiImage: UIImage?
+    private var isResizable: Bool = false
+
+    init(uiImage: UIImage?) {
+        self.uiImage = uiImage
+    }
+    
+    var body: some View {
+        var image: Image
+        
+        if let uiImage = self.uiImage {
+            image = Image(uiImage: uiImage)
+        } else {
+            image = Image(systemName: "")
+        }
+        
+        if isResizable {
+            image = image.resizable()
+        }
+
+        return image
+    }
+    
+    func resizable() -> SafeImage {
+        var view = self
+        view.isResizable = true
+        return view
+    }
+}

--- a/OpenArtemis/Views/OnboardingViews/OOBE_WelcomeView.swift
+++ b/OpenArtemis/Views/OnboardingViews/OOBE_WelcomeView.swift
@@ -17,7 +17,7 @@ struct OOBE_WelcomeView: View {
             VStack {
                 Spacer()
                 
-                Image(uiImage: UIImage(named: "AppIcon")!)
+                SafeImage(uiImage: UIImage(named: "AppIcon"))
                     .resizable()
                     .shadow(radius: 10)
                     .frame(width: 128, height: 128)

--- a/OpenArtemis/Views/Settings/ChangeAppIconView.swift
+++ b/OpenArtemis/Views/Settings/ChangeAppIconView.swift
@@ -32,7 +32,7 @@ struct AppIconElement: View {
     
     var body: some View {
         HStack{
-            Image(uiImage: UIImage(named: icon)!)
+            SafeImage(uiImage: UIImage(named: icon))
                 .resizable()
                 .frame(width: 48, height: 48)
                 .mask(RoundedRectangle(cornerSize: CGSize(width: 15, height: 15)))

--- a/OpenArtemis/Views/Settings/SettingsView.swift
+++ b/OpenArtemis/Views/Settings/SettingsView.swift
@@ -152,7 +152,7 @@ struct SettingsView: View {
                 
                 NavigationLink(destination: ChangeAppIconView(appTheme: appTheme, textSizePreference: textSizePreference), label: {
                     HStack{
-                        Image(uiImage: UIImage(named: currentAppIcon)!)
+                        SafeImage(uiImage: UIImage(named: "AppIcon"))
                             .resizable()
                             .frame(width: 24, height: 24)
                             .mask(RoundedRectangle(cornerSize: CGSize(width: 5, height: 5)))


### PR DESCRIPTION
SafeImage view because I can't load AppIcon's in UIImage